### PR TITLE
Fix: Env variables

### DIFF
--- a/bin/cli/base.js
+++ b/bin/cli/base.js
@@ -21,7 +21,7 @@ class Base extends Command {
         const env = dotenv.config().parsed || {};
         params = dotenv.parse(params.reduce((a, p) => a + '\n' + p, ''));
 
-        const envParams = { params: Object.assign(env, params) };
+        const envParams = { _: Object.assign(env, params) };
 
         const configFileDir = path.dirname(
             path.resolve(process.cwd(), configFile)

--- a/src/request.js
+++ b/src/request.js
@@ -1,10 +1,8 @@
 const request = require('request-promise-native');
-const RequestList = require('./requestList');
 const RequestCache = require('./requestCache');
 const Plugins = require('./plugins');
 
 const {
-    httpVerbs,
     requestRegex,
     replacementRegex,
     UpperCaseKeys,

--- a/src/requestList.js
+++ b/src/requestList.js
@@ -1,6 +1,5 @@
 const Request = require('./request');
 const RequestCache = require('./requestCache');
-const httpVerbs = require('./shared').httpVerbs;
 
 class RequestList {
     constructor(config = { REQUESTS: [] }) {


### PR DESCRIPTION
I am making a couple of small changes to how external environment
variables are used. From now own everything comming from the outside,
namely the .env file and the params flag are assigned to the '_'
variable within the internal environment. This is mostly to namespace
things and make it clear where they are coming from.