### PR TITLE
This fixes an issue where / and \ and : where considered valid names for

### DIFF
--- a/src/shared.js
+++ b/src/shared.js
@@ -11,7 +11,7 @@ const httpVerbs = [
 ];
 
 const requestRegex = new RegExp(`(${httpVerbs.join('|')})\\s(.*)`, 'i');
-const replacementRegex = /(?:\\?)\$([a-zA-Z\.\d\-\_\/\\\:]+)/g;
+const replacementRegex = /(?:\\?)\$([a-zA-Z\.\d\-\_]+)/g;
 const dynamicValueRegex = /\$\[(\w+\((?:.|[\n\r])*?\))\]/g;
 
 const UpperCaseKeys = function(obj) {


### PR DESCRIPTION
replacements.