### PR TITLE
Added flags for quiet and as-json output.

### DIFF
--- a/bin/cli/base.js
+++ b/bin/cli/base.js
@@ -41,7 +41,7 @@ Base.flags = {
     }),
     verbose: flags.boolean({
         char: 'V',
-        description: 'Show all additional information available for a command.'
+        description: `Show all additional information available for a command.`
     }),
     'no-format': flags.boolean({
         description: `Disables color formatting for usage on external tools.`


### PR DESCRIPTION
--as-json outputs the response as json, this allows you to use tools
like jq on the output which is nice.

--quiet makes it so no output is printed. I added this in case you are
looping Beau and don't want to see the output of every single request.
Example: `seq 10 | xargs -I{} beau request hi --quiet`.