### PR TITLE
Refactoring Object.keys into Object.entries

### DIFF
--- a/src/__tests__/__snapshots__/beau.spec.js.snap
+++ b/src/__tests__/__snapshots__/beau.spec.js.snap
@@ -36,18 +36,6 @@ Beau {
     ],
   },
   "requests": RequestList {
-    "PLUGINS": Plugins {
-      "autoload": Array [
-        "std",
-      ],
-      "context": Object {},
-      "registry": Object {
-        "dynamicValues": Array [],
-        "postRequestModifiers": Array [],
-        "preRequestModifiers": Array [],
-      },
-    },
-    "REQUESTS": Array [],
     "cache": RequestCache {
       "$cache": Object {
         "env": Object {},
@@ -60,34 +48,6 @@ Beau {
 
 exports[`Beau's config Loader. should load the request list using the configuration 1`] = `
 RequestList {
-  "PLUGINS": Plugins {
-    "autoload": Array [
-      "std",
-    ],
-    "context": Object {},
-    "registry": Object {
-      "dynamicValues": Array [],
-      "postRequestModifiers": Array [],
-      "preRequestModifiers": Array [],
-    },
-  },
-  "REQUESTS": Array [
-    Object {
-      "ALIAS": "get-post",
-      "COOKIEJAR": false,
-      "ENDPOINT": "http://example.com",
-      "REQUEST": "GET /posts/1",
-    },
-    Object {
-      "ALIAS": "user",
-      "COOKIEJAR": false,
-      "ENDPOINT": "http://example.com",
-      "HEADERS": Object {
-        "hello": "world",
-      },
-      "REQUEST": "GET /user",
-    },
-  ],
   "cache": RequestCache {
     "$cache": Object {
       "env": Object {},

--- a/src/config.js
+++ b/src/config.js
@@ -52,13 +52,13 @@ class Config {
     }
 
     loadRequests(host, settings) {
-        let requests = Object.keys(host)
-            .filter(key => requestRegex.test(key))
-            .map(key => {
-                let requestDefinitionIsString = typeof host[key] === 'string';
+        let requests = Object.entries(host)
+            .filter(([key]) => requestRegex.test(key))
+            .map(([key, rDefinition]) => {
+                let requestDefinitionIsString = typeof rDefinition === 'string';
                 let originalRequest = requestDefinitionIsString
-                    ? { ALIAS: host[key] }
-                    : host[key];
+                    ? { ALIAS: rDefinition }
+                    : rDefinition;
 
                 let request = UpperCaseKeys(originalRequest);
 
@@ -81,9 +81,9 @@ class Config {
     loadConfig(host) {
         let config = {};
 
-        Object.keys(host)
-            .filter(k => this.configKeys.includes(k.toUpperCase()))
-            .forEach(k => (config[k.toUpperCase()] = host[k]));
+        Object.entries(host)
+            .filter(([key]) => this.configKeys.includes(key.toUpperCase()))
+            .forEach(([key, value]) => (config[key.toUpperCase()] = value));
 
         return config;
     }

--- a/src/request.js
+++ b/src/request.js
@@ -41,11 +41,11 @@ class Request {
     findDependencies(request, set = new Set()) {
         let type = typeof request;
 
-        if (type === 'object') {
-            Object.keys(request)
-                .filter(key => key !== 'ALIAS')
-                .forEach(key => {
-                    set = this.findDependencies(request[key], set);
+        if (type === 'object' && request !== null) {
+            Object.entries(request)
+                .filter(([key]) => key !== 'ALIAS')
+                .forEach(([key, value]) => {
+                    set = this.findDependencies(value, set);
                 });
         } else if (type === 'string') {
             const matches = [];

--- a/src/requestList.js
+++ b/src/requestList.js
@@ -3,10 +3,7 @@ const RequestCache = require('./requestCache');
 
 class RequestList {
     constructor(config = { REQUESTS: [] }) {
-        this.PLUGINS = config.PLUGINS;
-        this.REQUESTS = config.REQUESTS;
-
-        this.list = this.loadRequests();
+        this.list = this.loadRequests(config.REQUESTS, config.PLUGINS);
         this.cache = new RequestCache();
 
         this.cache.add(`env`, config.ENVIRONMENT);
@@ -42,11 +39,11 @@ class RequestList {
         return this.cache;
     }
 
-    loadRequests() {
+    loadRequests(REQUESTS, PLUGINS) {
         let requests = [];
-        this.REQUESTS.forEach(request => {
+        REQUESTS.forEach(request => {
             try {
-                requests.push(new Request(request, this.PLUGINS));
+                requests.push(new Request(request, PLUGINS));
             } catch (e) {
                 throw new Error(`${request.request} was ignored: ${e}`);
             }

--- a/src/shared.js
+++ b/src/shared.js
@@ -16,7 +16,7 @@ const dynamicValueRegex = /\$\[(\w+\((?:.|[\n\r])*?\))\]/g;
 
 const UpperCaseKeys = function(obj) {
     let result = {};
-    Object.keys(obj).forEach(k => (result[k.toUpperCase()] = obj[k]));
+    Object.entries(obj).forEach(([k, v]) => (result[k.toUpperCase()] = v));
     return result;
 };
 
@@ -26,12 +26,12 @@ const isEmptyObject = obj =>
 const removeOptionalKeys = function(obj, optionalValues) {
     let result = {};
 
-    Object.keys(obj).forEach(key => {
-        if (optionalValues.includes(key) && isEmptyObject(obj[key])) {
+    Object.entries(obj).forEach(([key, value]) => {
+        if (optionalValues.includes(key) && isEmptyObject(value)) {
             return;
         }
 
-        result[key] = obj[key];
+        result[key] = value;
     });
 
     return result;
@@ -49,22 +49,19 @@ const replaceInObject = function(obj, fn) {
         return null;
     }
 
-    let type = typeof obj;
-
-    if (type === 'undefined') {
-        return {};
+    switch (typeof obj) {
+        case 'undefined':
+            return {};
+        case 'string':
+            return fn(obj);
+        case 'object':
+            obj = Object.assign({}, obj);
+            Object.entries(obj).forEach(
+                ([key, value]) => (obj[key] = replaceInObject(value, fn))
+            );
+        default:
+            return obj;
     }
-
-    if (type === 'string') {
-        return fn(obj);
-    }
-
-    if (type === 'object') {
-        obj = Object.assign({}, obj);
-        Object.keys(obj).forEach(k => (obj[k] = replaceInObject(obj[k], fn)));
-    }
-
-    return obj;
 };
 
 const moduleVersion = () => parseInt(require('../package.json').version, 10);


### PR DESCRIPTION
Basically I like how when using Object.entries you can destructure and
name the value. It feels a lot more explicit to give the value a name
rather than refer to it as obj[k]. The syntax is not super pretty though.